### PR TITLE
Change the title for the menu

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackRecordedActivity.java
@@ -123,7 +123,7 @@ public class TrackRecordedActivity extends AbstractTrackDeleteActivity implement
     private void showSelectionMenu() {
         final CharSequence[] items = {"5", "10", "15"};
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setTitle("Select value");
+        builder.setTitle("Select Number of Points for Moving Average");
         builder.setItems(items, (dialog, which) -> {
             // 'which' is the index of the selected item
             int selectedValue = Integer.parseInt(items[which].toString());


### PR DESCRIPTION
The title of the menu that opens once the user clicks on the button has been modified to allow for better user experience and to avoid the user from being confused and for the user also to understand clearly what is going on.
